### PR TITLE
Bugfix propensity

### DIFF
--- a/biocrnpyler/sbmlutil.py
+++ b/biocrnpyler/sbmlutil.py
@@ -238,16 +238,12 @@ def _create_products(product_list, sbml_reaction, model):
 def _create_modifiers(crn_reaction, sbml_reaction, model):
     reactants_list = crn_reaction.inputs
     products_list = crn_reaction.outputs
-    propensity = crn_reaction.propensity_type
-    if propensity.name == 'massaction':
-        # No modifier species reference needed
-        return
-    else:
-        modifier_species = [propensity.s1, propensity.d]
-        for modifier_id in modifier_species:
-            if modifier_id not in reactants_list and modifier_id not in products_list:
-                modifier = sbml_reaction.createModifier()
-                modifier.setSpecies(modifier_id)
+    modifier_species = crn_reaction.propensity_type.propensity_dict['species']
+
+    for modifier_id in modifier_species:
+        if modifier_id not in reactants_list and modifier_id not in products_list:
+            modifier = sbml_reaction.createModifier()
+            modifier.setSpecies(modifier_id)
     
 #Creates a local parameter SBML kinetic rate law
 def _create_local_parameter(ratelaw, name, value, constant = True):


### PR DESCRIPTION
Hi Ayush,

I tried to patch up the bug with the ```annotation_dict```, I __think__, it is okay now, but there's still validation error in the sbml test, so there's still things to do.

The main thing is a new function called ```_translate_propensity_dict_to_sbml(model=model, ratelaw=ratelaw)``` which is called in both ```Massaction``` and ```Hill``` to 'translate' the self.propensity_dict into an sbml dictionary (species are sbml species IDs and parameters are sbml parameter objects).
The ```propensity_dict_in_sbml``` is passed into ```create_annotation```. The same ```propensity_dict_in_sbml```  is used to generate the rate formula in ```Massaction```, ```Hill``` and its subclasses


btw, there was a small bug with ```_create_modifiers()```, I added a fix in a separate commit so can grab it if you want it.



